### PR TITLE
add equation numbering and reference support

### DIFF
--- a/_includes/utils/mathjax.html
+++ b/_includes/utils/mathjax.html
@@ -6,3 +6,12 @@
 	</script>
 	<script type="text/javascript" async src="//cdn.bootcss.com/mathjax/2.7.2/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 {%- endif -%}
+
+{%- if site.mathjax_autoNumber == true or page.mathjax_autoNumber == true % -%}
+	<script type="text/x-mathjax-config">
+  		MathJax.Hub.Config({
+    			TeX: { equationNumbers: { autoNumber: "all" } }
+  		});
+  	</script>
+	<script type="text/javascript" async src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+{%- endif -%}


### PR DESCRIPTION
Hi, I included a second variable, "mathjax_autoNumber", to enable support for equation autoNumbering and referencing. I think this feature is very useful for people who write a lot of math equations on the posts.

The official documentation of this feature: 
http://docs.mathjax.org/en/latest/tex.html#automatic-equation-numbering

How the post looks like with equation autoNumbering & referencing:
https://liao961120.github.io/2018/01/27/mathjax.html

The post mentioned above at GitHub (.md):
https://github.com/liao961120/liao961120.github.io/blob/master/_posts/2018-01-27-mathjax.md