### PR TITLE
Add Anonymize IP option for GA

### DIFF
--- a/_config.demo.yml
+++ b/_config.demo.yml
@@ -133,7 +133,7 @@ leancloud:
 ##############################
 ## Google Analytics
 ga_tracking_id: UA-71907556-1 #Google analytics id for the site
-
+ga_anonymize_ip: false # Anonymize IP tracking for Analytics
 
 ## => Build
 ##############################

--- a/_config.dev.yml
+++ b/_config.dev.yml
@@ -133,7 +133,7 @@ leancloud:
 ##############################
 ## Google Analytics
 ga_tracking_id: # Google Analytics id for the site
-
+ga_anonymize_ip: false # Anonymize IP tracking for Analytics
 
 ## => Build
 ##############################

--- a/_config.yml
+++ b/_config.yml
@@ -131,7 +131,7 @@ leancloud:
 ##############################
 ## Google Analytics
 ga_tracking_id: # Google Analytics id for the site
-
+ga_anonymize_ip: false # Anonymize IP tracking for Analytics
 
 ## => Build
 ##############################

--- a/_includes/analytics-providers/google.html
+++ b/_includes/analytics-providers/google.html
@@ -8,6 +8,9 @@
 
 		ga('create', '{{ site.ga_tracking_id }}', 'auto');
 		ga('send', 'pageview');
+		{% if site.ga_anonymize_ip == true %}
+		ga('set', 'anonymizeIp', true);
+		{% endif %}
 	</script>
 
 {%- endif -%}


### PR DESCRIPTION
This should at least partially tackle #62 regarding analytics, however I also need to know(preferably before the 25th) if and where other cookies are used/stored.