### PR TITLE
fix: item__content width over the limit

### DIFF
--- a/_sass/common/components/_item.scss
+++ b/_sass/common/components/_item.scss
@@ -18,6 +18,7 @@
 
 .item__content {
   @include flex(1);
+  max-width: 100%;
 }
 
 .item__header {


### PR DESCRIPTION
解决因为代码单行过长把整个文章区域撑开的问题