### PR TITLE
Add 'addthis' as another sharing provider

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -106,8 +106,9 @@ sources: # bootcdn (default), unpkg
 ## => Sharing
 ##############################
 sharing:
-  provider: false # false (default), "addtoany"
-
+  provider: false # false (default), "addtoany", "addthis"
+  addthis:
+    id: ra-5xxxxxxxxxxx
 
 ## => Comments
 ##############################

--- a/_includes/sharing-providers/addthis.html
+++ b/_includes/sharing-providers/addthis.html
@@ -1,0 +1,3 @@
+  <!-- Addthis Sharing -->
+  <script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid={{ site.sharing.addthis.id }}"></script>
+  <div class="addthis_inline_share_toolbox addthis_default_style"></div> 

--- a/_includes/sharing.html
+++ b/_includes/sharing.html
@@ -1,3 +1,5 @@
 {%- if site.sharing.provider == 'addtoany' -%}
   {%- include sharing-providers/addtoany.html -%}
+{%- elsif site.sharing.provider == 'addthis' -%}
+  {%- include sharing-providers/addthis.html -%}
 {%- endif -%}


### PR DESCRIPTION
I found [AddThis](https://www.addthis.com) as another popular alternative to [AddToAny](https://www.addtoany.com/), so I add it to the TeXt template.
I've test it and it works fine on github pages and my local computer. 

Thanks again for the fantastic TeXt theme.