### PR TITLE
fix "from" and "here" spellings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@
 
 ## 2.0.0 (2018-07-01)
 
-Breaking changes, please check [Update form 1.x to 2.x](https://tianqi.name/jekyll-TeXt-theme/docs/en/update-form-1-to-2) for details
+Breaking changes, please check [Update from 1.x to 2.x](https://tianqi.name/jekyll-TeXt-theme/docs/en/update-form-1-to-2) for details
 
 ### Enhancements
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ TeXt use [Tomorrow](https://github.com/chriskempson/tomorrow-theme) as the highl
 ### Start
 
 - [Quick Start](https://tianqi.name/jekyll-TeXt-theme/docs/en/quick-start)
-- [Update form 1.x to 2.x](https://tianqi.name/jekyll-TeXt-theme/docs/en/update-form-1-to-2)
+- [Update from 1.x to 2.x](https://tianqi.name/jekyll-TeXt-theme/docs/en/update-form-1-to-2)
 
 ### Customization
 

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -20,7 +20,7 @@ docs-en:
         url:    /docs/en/quick-start
       - title:  Structure
         url:    /docs/en/structure
-      - title:  Update form 1.x to 2.x
+      - title:  Update from 1.x to 2.x
         url:    /docs/en/update-form-1-to-2
   - title:      Customization
     children:

--- a/docs/_docs/en/1.7-update-form-1-to-2.md
+++ b/docs/_docs/en/1.7-update-form-1-to-2.md
@@ -1,5 +1,5 @@
 ---
-title: Update form 1.x to 2.x
+title: Update from 1.x to 2.x
 permalink: /docs/en/update-form-1-to-2
 key: docs-update-form-1-to-2
 ---

--- a/docs/_docs/en/2.1-configuration.md
+++ b/docs/_docs/en/2.1-configuration.md
@@ -269,7 +269,7 @@ comments:
     id: "your-addthis-pubid"
 ```
 
-You NEED set `sharing` variable as `true` in the page’s YAML Front Matter to enable sharing on this page, you can find more information [HRER](https://tianqi.name/jekyll-TeXt-theme/docs/en/layouts#article-layout).
+You NEED set `sharing` variable as `true` in the page’s YAML Front Matter to enable sharing on this page, you can find more information [HERE](https://tianqi.name/jekyll-TeXt-theme/docs/en/layouts#article-layout).
 {:.warning}
 
 ## Comments
@@ -307,7 +307,7 @@ comments:
       - "the-other-admin-github-id"
 ```
 
-For all the above comments systems, you NEED set `key` variable in the page’s YAML Front Matter to enable comments on this page, you can find more information [HRER](https://tianqi.name/jekyll-TeXt-theme/docs/en/layouts#page-layout).
+For all the above comments systems, you NEED set `key` variable in the page’s YAML Front Matter to enable comments on this page, you can find more information [HERE](https://tianqi.name/jekyll-TeXt-theme/docs/en/layouts#page-layout).
 {:.warning}
 
 ## Pageview
@@ -332,7 +332,7 @@ pageview:
     app_class : "your-leanCloud-app-class"
 ```
 
-For all the above pageview statistics, you **NEED** set `key` variable in the page’s YAML Front Matter to enable statistics on this page, you can find more information [HRER](https://tianqi.name/jekyll-TeXt-theme/docs/en/layouts#page-layout).
+For all the above pageview statistics, you **NEED** set `key` variable in the page’s YAML Front Matter to enable statistics on this page, you can find more information [HERE](https://tianqi.name/jekyll-TeXt-theme/docs/en/layouts#page-layout).
 {:.warning}
 
 ## Analytics


### PR DESCRIPTION
I've kept the permalinks and keys unchanged for compatibility.