### PR TITLE
remove internal `@import` for highlight color

### DIFF
--- a/_sass/skins/_chocolate.scss
+++ b/_sass/skins/_chocolate.scss
@@ -64,6 +64,3 @@ $github-color:     #000;
 $linkedin-color:   #1074af;
 $npm-color:        #fff;
 $telegram-color:   #32afed;
-
-// highlight colors
-@import "skins/highlight/tomorrow-night-eighties";

--- a/_sass/skins/_dark.scss
+++ b/_sass/skins/_dark.scss
@@ -64,6 +64,3 @@ $github-color:     #000;
 $linkedin-color:   #1074af;
 $npm-color:        #fff;
 $telegram-color:   #32afed;
-
-// highlight colors
-@import "skins/highlight/tomorrow-night";

--- a/_sass/skins/_default.scss
+++ b/_sass/skins/_default.scss
@@ -64,6 +64,3 @@ $github-color:     #000;
 $linkedin-color:   #1074af;
 $npm-color:        #fff;
 $telegram-color:   #32afed;
-
-// highlight colors
-@import "skins/highlight/tomorrow";

--- a/_sass/skins/_forest.scss
+++ b/_sass/skins/_forest.scss
@@ -64,6 +64,3 @@ $github-color:     #000;
 $linkedin-color:   #1074af;
 $npm-color:        #fff;
 $telegram-color:   #32afed;
-
-// highlight colors
-@import "skins/highlight/tomorrow";

--- a/_sass/skins/_ocean.scss
+++ b/_sass/skins/_ocean.scss
@@ -64,6 +64,3 @@ $github-color:     #000;
 $linkedin-color:   #1074af;
 $npm-color:        #fff;
 $telegram-color:   #32afed;
-
-// highlight colors
-@import "skins/highlight/tomorrow-night-blue";

--- a/_sass/skins/_orange.scss
+++ b/_sass/skins/_orange.scss
@@ -64,6 +64,3 @@ $github-color:     #000;
 $linkedin-color:   #1074af;
 $npm-color:        #fff;
 $telegram-color:   #32afed;
-
-// highlight colors
-@import "skins/highlight/tomorrow-night-eighties";


### PR DESCRIPTION
This is redundant because main.scss already does this, at
https://github.com/kitian616/jekyll-TeXt-theme/blob/v2.2.3/assets/css/main.scss#L17

Fixes #118.