### PR TITLE
Google Custom Search - Fix missing colon

### DIFF
--- a/_includes/search-providers/google-custom-search-engine/search.js
+++ b/_includes/search-providers/google-custom-search-engine/search.js
@@ -27,7 +27,7 @@ window.Lazyload.js(SOURCES.jquery, function() {
   };
   var cx = '{{ site.search.google.custom_search_engine_id }}'; // Insert your own Custom Search Engine ID here
   var gcse = document.createElement('script'); gcse.type = 'text/javascript'; gcse.async = true;
-  gcse.src = (document.location.protocol == 'https' ? 'https:' : 'http:') +
+  gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') +
     '//www.google.com/cse/cse.js?cx=' + cx;
   var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gcse, s);
 });


### PR DESCRIPTION
This fixes an issue that prevents GCS from loading properly (or at least without the user explicitly bypassing a warning in their browser) on https pages.