### PR TITLE
valine-visitor&config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -140,6 +140,8 @@ comments:
     app_id      : # LeanCloud App id
     app_key     : # LeanCloud App key
     placeholder : # Prompt information
+    visitor     : # false (default)
+    meta        : # "[nick, mail, link]" (default) nickname, E-mail, Personal-site
 
 
 ## => Pageview

--- a/_includes/comments-providers/valine.html
+++ b/_includes/comments-providers/valine.html
@@ -4,13 +4,20 @@
 {%- assign _VALINE_APP_ID = site.comments.valine.app_id -%}
 {%- assign _VALINE_APP_KEY = site.comments.valine.app_key -%}
 {%- assign _VALINE_PLACEHOLDER = site.comments.valine.placeholder -%}
+{%- assign _VALINE_VISITOR = site.comments.valine.visitor -%}
+{%- assign _VALINE_META = site.comments.valine.meta -%}
 
 
-{%- if page.key and
-  _VALINE_APP_ID and
+{%- if _VALINE_APP_ID and
   _VALINE_APP_KEY -%}
 
 <div id="vcomments"></div>
+
+{%- if _VALINE_VISITOR -%}    
+<span id="{{page.url}}" class="leancloud-visitors" data-flag-title={{page.title}}>
+</span>
+{%- endif -%}
+
 <script>
   window.Lazyload.js(['{{ _sources.leancloud_js_sdk}}', '{{ _sources.valine }}'], function() {
     var _config = {
@@ -25,6 +32,12 @@
     {%- assign _page_lang_slice =  page.lang | slice: 0, 2 -%}
     {%- if _page_lang_slice != 'zh'  -%}
       _config.lang = 'en';
+    {%- endif -%}  
+    {%- if _VALINE_VISITOR -%}
+      _config.visitor = 'true';
+    {%- endif -%}
+    {%- if _VALINE_META -%}
+      _config.meta = {{ _VALINE_META}};
     {%- endif -%}
     new Valine(_config);
   });


### PR DESCRIPTION
1. fix: valine does not require a key. Instead, page url is used for the same purpose.
2. feature: valine can count the pageviews at the same time.
  (but the count can only be seen in leancloud console. )
2. enable more customised configuration (meta)

* Btw it is not reasonable that valine is English when the site.lang is "zh". 