### PR TITLE
fix: pageview on articles layout

### DIFF
--- a/_includes/pageview.html
+++ b/_includes/pageview.html
@@ -2,7 +2,7 @@
 {%- assign _pageview = __return -%}
 
 
-{%- if page.layout == "home" -%}
+{%- if page.layout == "home" or page.layout == "articles" -%}
 
   {%- if jekyll.environment != "development" -%}
     {%- if site.pageview.provider == 'leancloud' -%}

--- a/_sass/common/components/_item.scss
+++ b/_sass/common/components/_item.scss
@@ -7,6 +7,9 @@
 
 .item__image {
   margin-right: map-get($spacers, 3);
+  display: grid;
+  justify-content: center;
+  align-items: center;
   & + .item__content {
     & > :first-child {
       margin-top: 0;


### PR DESCRIPTION
When index.html's layout is set to `articles`, pageview function will not be included even it's enabled.