### PR TITLE
Use 'jsonify' instead of 'url_encode' for JavaScript data export

### DIFF
--- a/_includes/pageview-providers/leancloud/post.html
+++ b/_includes/pageview-providers/leancloud/post.html
@@ -21,7 +21,7 @@
         appClass: '{{ _LEANCLOUD_APP_CLASS }}'
       });
       var key =   '{{ page.key }}';
-      var title = window.decodeUrl('{{ page.title | url_encode }}');
+      var title = {{ page.title | jsonify }};
       pageview.increase(key, title, function(view) {
         $("[data-page-key='{{ page.key }}']").text(view);
       });

--- a/_includes/scripts/utils/utils.js
+++ b/_includes/scripts/utils/utils.js
@@ -6,10 +6,6 @@
     return typeof val === 'string';
   };
 
-  window.decodeUrl = function(str) {
-    return str ? decodeURIComponent(str.replace(/\+/g, '%20')) : '';
-  };
-
   window.hasEvent = function(event) {
     return 'on'.concat(event) in window.document;
   };

--- a/_includes/search-providers/default/search-data.js
+++ b/_includes/search-providers/default/search-data.js
@@ -4,10 +4,10 @@ window.TEXT_SEARCH_DATA={
     '{{ _collection.label }}':[
       {%- for _article in _collection.docs -%}
       {%- unless forloop.first -%},{%- endunless -%}
-      {'title':'{{ _article.title | url_encode }}',
+      {'title':{{ _article.title | jsonify }},
       {%- include snippets/prepend-baseurl.html path=_article.url -%}
       {%- assign _url = __return -%}
-      'url':'{{ _url | url_encode }}'}
+      'url':{{ _url | jsonify }}}
       {%- endfor -%}
     ]
   {%- endfor -%}

--- a/_includes/search-providers/default/search.js
+++ b/_includes/search-providers/default/search.js
@@ -2,7 +2,7 @@ var SOURCES = window.TEXT_VARIABLES.sources;
 var PAHTS = window.TEXT_VARIABLES.paths;
 window.Lazyload.js([SOURCES.jquery, PAHTS.search_js], function() {
   var search = (window.search || (window.search = {}));
-  var searchData = window.TEXT_SEARCH_DATA ? initData(window.TEXT_SEARCH_DATA) : {};
+  var searchData = window.TEXT_SEARCH_DATA || {};
 
   function memorize(f) {
     var cache = {};
@@ -11,21 +11,6 @@ window.Lazyload.js([SOURCES.jquery, PAHTS.search_js], function() {
       if (key in cache) return cache[key];
       else return cache[key] = f.apply(this, arguments);
     };
-  }
-
-  function initData(data) {
-    var _data = [], i, j, key, keys, cur;
-    keys = Object.keys(data);
-    for (i = 0; i < keys.length; i++) {
-      key = keys[i], _data[key] = [];
-      for (j = 0; j < data[key].length; j++) {
-        cur = data[key][j];
-        cur.title = window.decodeUrl(cur.title);
-        cur.url = window.decodeUrl(cur.url);
-        _data[key].push(cur);
-      }
-    }
-    return _data;
   }
 
   /// search


### PR DESCRIPTION
The JSON data format is natively compatible with the parsing of
JavaScript code. It can be used as the literal value of any
JavaScript variable or JavaScript object property value.

Previously:

> ```js
> window.DATA = {'title':'Foo%20%22Bar%22'};
> title = decodeUrl(DATE.title);
> ```

Now:
> ```js
> window.DATA = {'title':"Foo \"Bar\""};
> title = DATE.title;
> ```