### PR TITLE
feat: center cover on homepage

### DIFF
--- a/_sass/common/components/_item.scss
+++ b/_sass/common/components/_item.scss
@@ -7,6 +7,9 @@
 
 .item__image {
   margin-right: map-get($spacers, 3);
+  display: grid;
+  justify-content: center;
+  align-items: center;
   & + .item__content {
     & > :first-child {
       margin-top: 0;


### PR DESCRIPTION
Center cover images horizontally and vertically as described in #154.

close #154.