### PR TITLE
Remove redundant file logo.svg and use the file located in 'assets' folder

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,7 +8,9 @@
     <div class="main">
       <div class="header__title">
         <div class="header__brand">
-          {%- include svg/logo.svg -%}
+          {%- include snippets/prepend-baseurl.html path='/assets/images/logo/logo.svg' -%}
+          <object data="{{ __return }}" type="image/svg+xml"></object>
+
           {%- assign _paths_root = site.paths.root | default: site.data.variables.default.paths.root  -%}
           {%- include snippets/get-nav-url.html path=_paths_root -%}
           {%- if site.title -%}

--- a/_includes/svg/logo.svg
+++ b/_includes/svg/logo.svg
@@ -1,8 +1,0 @@
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="24px" height="24px" viewBox="0 0 24 24">
-<style type="text/css">
-	.st0{fill:#515151;}
-</style>
-<path class="st0" d="M1.7,22.3c5.7-5.7,11.3-5.7,17,0c3.3-3.3,3.5-5.3,0.8-6c2.7,0.7,3.5-1.1,2.3-5.6s-3.3-5.2-6.3-2.1
-	c3-3,2.3-5.2-2.1-6.3S7,1.8,7.7,4.6C7,1.8,5,2.1,1.7,5.3C7.3,11,7.3,16.7,1.7,22.3"/>
-</svg>

--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -63,7 +63,7 @@
 .header__brand {
   @include flexbox();
   @include align-items(center);
-  & > svg {
+  & > svg, & > object {
     width: map-get($base, font-size-h4) * 1.6;
     height: map-get($base, font-size-h4) * 1.6;
     margin-right: map-get($spacers, 3);


### PR DESCRIPTION
Currently, when you want to change the logo of the project, you have to change the file logo.svg in :

- **assets/images/logo.svg** : Used in the pages/articles...
- **_includes/svg/logo.svg** : Used in the header

I made a little modification to keep only the version of this file in the assets folder by using snippets/prepend-baseurl.html snippet.