### PR TITLE
紧急修复：leancloud 域名被封，指向新域名

### DIFF
--- a/_data/variables.yml
+++ b/_data/variables.yml
@@ -43,7 +43,7 @@ sources:
   bootcdn:
     font_awesome: 'https://use.fontawesome.com/releases/v5.0.13/css/all.css'
     jquery: 'https://cdn.bootcss.com/jquery/3.1.1/jquery.min.js'
-    leancloud_js_sdk: '//cdn1.lncld.net/static/js/3.4.1/av-min.js'
+    leancloud_js_sdk: '//cdn.jsdelivr.net/npm/leancloud-storage@3.13.2/dist/av-min.js'
     chart: 'https://cdn.bootcss.com/Chart.js/2.7.2/Chart.bundle.min.js'
     gitalk:
       js: 'https://cdn.bootcss.com/gitalk/1.2.2/gitalk.min.js'
@@ -54,7 +54,7 @@ sources:
   unpkg:
     font_awesome: 'https://use.fontawesome.com/releases/v5.0.13/css/all.css'
     jquery: 'https://unpkg.com/jquery@3.3.1/dist/jquery.min.js'
-    leancloud_js_sdk: '//cdn1.lncld.net/static/js/3.4.1/av-min.js'
+    leancloud_js_sdk: '//cdn.jsdelivr.net/npm/leancloud-storage@3.13.2/dist/av-min.js'
     chart: 'https://unpkg.com/chart.js@2.7.2/dist/Chart.min.js'
     gitalk:
       js: 'https://unpkg.com/gitalk@1.2.2/dist/gitalk.min.js'

--- a/_includes/pageview-providers/leancloud/leancloud.js
+++ b/_includes/pageview-providers/leancloud/leancloud.js
@@ -6,13 +6,14 @@
     }
   }
 
-  function pageview(_AV  ,options) {
+  function pageview(_AV, options) {
     var AV = _AV;
     var appId, appKey, appClass;
     appId = options.appId;
     appKey = options.appKey;
     appClass = options.appClass;
     AV.init({
+      serverURLs: 'https://avoscloud.com',
       appId: appId,
       appKey: appKey
     });

--- a/docs/_data/variables.yml
+++ b/docs/_data/variables.yml
@@ -43,7 +43,7 @@ sources:
   bootcdn:
     font_awesome: 'https://use.fontawesome.com/releases/v5.0.13/css/all.css'
     jquery: 'https://cdn.bootcss.com/jquery/3.1.1/jquery.min.js'
-    leancloud_js_sdk: '//cdn1.lncld.net/static/js/3.4.1/av-min.js'
+    leancloud_js_sdk: '//cdn.jsdelivr.net/npm/leancloud-storage@3.13.2/dist/av-min.js'
     chart: 'https://cdn.bootcss.com/Chart.js/2.7.2/Chart.bundle.min.js'
     gitalk:
       js: 'https://cdn.bootcss.com/gitalk/1.2.2/gitalk.min.js'
@@ -54,7 +54,7 @@ sources:
   unpkg:
     font_awesome: 'https://use.fontawesome.com/releases/v5.0.13/css/all.css'
     jquery: 'https://unpkg.com/jquery@3.3.1/dist/jquery.min.js'
-    leancloud_js_sdk: '//cdn1.lncld.net/static/js/3.4.1/av-min.js'
+    leancloud_js_sdk: '//cdn.jsdelivr.net/npm/leancloud-storage@3.13.2/dist/av-min.js'
     chart: 'https://unpkg.com/chart.js@2.7.2/dist/Chart.min.js'
     gitalk:
       js: 'https://unpkg.com/gitalk@1.2.2/dist/gitalk.min.js'

--- a/test/_data/variables.yml
+++ b/test/_data/variables.yml
@@ -43,7 +43,7 @@ sources:
   bootcdn:
     font_awesome: 'https://use.fontawesome.com/releases/v5.0.13/css/all.css'
     jquery: 'https://cdn.bootcss.com/jquery/3.1.1/jquery.min.js'
-    leancloud_js_sdk: '//cdn1.lncld.net/static/js/3.4.1/av-min.js'
+    leancloud_js_sdk: '//cdn.jsdelivr.net/npm/leancloud-storage@3.13.2/dist/av-min.js'
     chart: 'https://cdn.bootcss.com/Chart.js/2.7.2/Chart.bundle.min.js'
     gitalk:
       js: 'https://cdn.bootcss.com/gitalk/1.2.2/gitalk.min.js'
@@ -54,7 +54,7 @@ sources:
   unpkg:
     font_awesome: 'https://use.fontawesome.com/releases/v5.0.13/css/all.css'
     jquery: 'https://unpkg.com/jquery@3.3.1/dist/jquery.min.js'
-    leancloud_js_sdk: '//cdn1.lncld.net/static/js/3.4.1/av-min.js'
+    leancloud_js_sdk: '//cdn.jsdelivr.net/npm/leancloud-storage@3.13.2/dist/av-min.js'
     chart: 'https://unpkg.com/chart.js@2.7.2/dist/Chart.min.js'
     gitalk:
       js: 'https://unpkg.com/gitalk@1.2.2/dist/gitalk.min.js'


### PR DESCRIPTION
1. 更新 leancloud js SDK 版本
1. 指向 leancloud 最新域名

leancloud 域名暂时被封且可能无法解封，详见：https://blog.avoscloud.com/6805/ 以及 https://blog.avoscloud.com/6812/