### PR TITLE
Add (encrypted) contact form for landing pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -177,6 +177,15 @@ analytics:
     anonymize_ip: false # Anonymize IP tracking for Analytics
 
 
+## => Contact Form
+##############################
+contact:
+  provider: # false (default), "fncontact", "custom"
+  pgp_public_key: # Base64-encoded PGP Public Key (default: none)
+
+  ## fnContact
+  fncontact:
+    id: # Your Form ID
 ## => Build
 ##############################
 markdown    : kramdown

--- a/_data/variables.yml
+++ b/_data/variables.yml
@@ -51,6 +51,7 @@ sources:
     valine: 'https://unpkg.com/valine/dist/Valine.min.js' # bootcdn not available
     mathjax: 'https://cdn.bootcss.com/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_CHTML'
     mermaid: 'https://cdn.bootcss.com/mermaid/8.0.0-rc.8/mermaid.min.js'
+    openpgp: 'https://www.unpkg.com/openpgp@4.6.0/dist/openpgp.min.js' # bootcdn not available
   unpkg:
     font_awesome: 'https://use.fontawesome.com/releases/v5.0.13/css/all.css'
     jquery: 'https://unpkg.com/jquery@3.3.1/dist/jquery.min.js'
@@ -60,5 +61,4 @@ sources:
       js: 'https://unpkg.com/gitalk@1.2.2/dist/gitalk.min.js'
       css: 'https://unpkg.com/gitalk@1.2.2/dist/gitalk.css'
     valine: 'https//unpkg.com/valine/dist/Valine.min.js'
-    mathjax: 'https://unpkg.com/mathjax@2.7.4/unpacked/MathJax.js?config=TeX-MML-AM_CHTML'
-    mermaid: 'https://unpkg.com/mermaid@8.0.0-rc.8/dist/mermaid.min.js'
+    openpgp: 'https://www.unpkg.com/openpgp/dist/openpgp.min.js'

--- a/_includes/contact-form-providers/custom.html
+++ b/_includes/contact-form-providers/custom.html
@@ -1,0 +1,3 @@
+<!-- start custom contact form snippet -->
+
+<!-- end custom contact form snippet -->

--- a/_includes/contact-form-providers/fncontact.html
+++ b/_includes/contact-form-providers/fncontact.html
@@ -1,0 +1,28 @@
+{%- if site.contact.fncontact.id -%}
+<form id="contact-form" action="https://fncontact.com/{{ site.contact.fncontact.id }}/post" method="POST" onsubmit="return submitForm();">
+  {%- for field in include.fields -%}
+    {%- assign type = field.type | default: 'text' -%}
+    {%- if type != "submit" -%}
+      <label for="{{ field.name }}">{{ field.text }}</label>
+    {%- endif -%}
+    {%- assign tag = field.tag | default: "input" -%}
+    {%- if field.required == true -%}
+      {%- assign required = "required " -%}
+    {%- endif -%}
+    {%- if tag == "textarea" -%}
+      {%- assign closing_tag = "></textarea>" -%}
+      {%- else -%}
+        {%- assign closing_tag = ">" -%}
+    {%- endif -%}
+    {%- if forloop.last -%}
+      <div id="fnContactCaptcha"></div>
+      <script src="https://fncontact.com/captcha.js"></script>        
+    {%- endif -%}
+    <{{ tag }} encrypt="{{ field.encrypt | default: false }}" type="{{ type }}" id="{{ field.id | default: field.name}}" name="{{ field.name }}"
+      placeholder="{{ field.placeholder | default: '' }}" {{ required }} {%- if field.style -%} style="{{ field.style }}"
+      {%- endif -%} {%- if field.value -%} value="{{ field.value }}" {%- endif -%}{{ closing_tag }}
+
+    {% endfor %}
+
+</form>
+{%- endif -%}

--- a/_includes/contact-form.html
+++ b/_includes/contact-form.html
@@ -1,0 +1,4 @@
+{%- if site.contact.provider -%}
+  <script type="text/javascript">{%- include scripts/components/contact-form.js -%}</script>
+  {%- include contact-form-providers/{{ site.contact.provider }}.html fields=include.fields -%}
+{%- endif -%}

--- a/_includes/scripts/components/contact-form.js
+++ b/_includes/scripts/components/contact-form.js
@@ -1,0 +1,34 @@
+function encryptElement(pubKey, element) {
+  var SOURCES = window.TEXT_VARIABLES.sources;
+  window.Lazyload.js(SOURCES.openpgp, async function () {
+    let options = {
+      message: openpgp.message.fromText(element.value),
+      publicKeys: (await openpgp.key.readArmored(pubKey)).keys
+    };
+    openpgp.encrypt(options).then(ciphertext => {
+      element.value = ciphertext.data;
+      element.setAttribute("encrypt", "false");      
+    });
+  });
+};
+
+function submitForm() {
+  let validForm = $('#contact-form:valid');
+  if (validForm) {
+    let submit = validForm.get(0).submit;
+    let toEncrypt = validForm.find("[encrypt=true]");
+    if (window.TEXT_VARIABLES.pubKey && toEncrypt.length) {
+      if (submit) submit.value = "Encrypting...";
+      toEncrypt.each(function () {
+        encryptElement(atob(window.TEXT_VARIABLES.pubKey), this);
+      });
+      setTimeout(submitForm, 1000);
+    }
+    else {
+      if (submit) submit.value = "Submitting...";
+      HTMLFormElement.prototype.submit.call(validForm.get(0));
+    }
+  }
+  return false;
+
+}

--- a/_includes/scripts/variables.html
+++ b/_includes/scripts/variables.html
@@ -19,7 +19,8 @@
         },
         valine: '{{ _sources.valine }}',
         mathjax: '{{ _sources.mathjax }}',
-        mermaid: '{{ _sources.mermaid }}'
+        mermaid: '{{ _sources.mermaid }}',
+        openpgp: '{{ _sources.openpgp }}'
       },
       site: {
         toc: {
@@ -28,7 +29,8 @@
       },
       paths: {
         search_js: '{{ _paths_search_js }}'
-      }
+      },
+      pubKey: '{{ site.contact.pgp_public_key }}'
     };
     window.TEXT_VARIABLES = TEXT_VARIABLES;
   })();

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -124,6 +124,9 @@ article_header:
 
               </div>
             </div>
+            {%- if _section.type == "contact" -%}
+              {% include contact-form.html, fields: section.fields %}
+            {%- endif -%}
           {%- endif -%}
 
       {%- if _section.image.full_width == true -%}

--- a/docs/_docs/en/1.2-structure.md
+++ b/docs/_docs/en/1.2-structure.md
@@ -13,6 +13,7 @@ key: docs-structure
 │   ├── analytics-providers
 │   ├── aside
 │   ├── comments-providers
+│   ├── contact-form-providers
 │   ├── markdown-enhancements
 │   ├── pageview-providers
 │   ├── scripts


### PR DESCRIPTION
Can be enabled as such:
```yaml
sections:
  - type: contact
    fields:
    -  type:
       name:
       value:
       label:
       text:
       required:
       placeholder:
       tag:
       encrypt:
```