### PR TITLE
added gitalk implemantion

### DIFF
--- a/docs/_docs/en/2.1-configuration.md
+++ b/docs/_docs/en/2.1-configuration.md
@@ -303,6 +303,7 @@ comments:
       - "your-github-id"
       - "the-other-admin-github-id"
 ```
+Since gitalk uses github Issues, you need to update your repository `Settings`. You can enable `Issues` under `Settings`/ `Features` of your repository.
 
 ### Valine
 


### PR DESCRIPTION
https://github.com/kitian616/jekyll-TeXt-theme/issues/235

I had an issue implementing gitalk to my blog.
Kindly, @zouyu4524 helped me.
I thought adding the explanation to `doc` would help the others.
Still, I need help with adding the explanation in Chinese. 