### PR TITLE
fix: _header_background_image_src

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -100,7 +100,7 @@ layout: base
             {%- if page.article_header.background_image.gradient -%}
               {%- assign _header_background_image = page.article_header.background_image.gradient -%}
               {%- if _header_background_image_src -%}
-                {%- assign _header_background_image = _header_background_image | append: ',' -%}
+                {%- assign _header_background_image = _header_background_image_src | append: ',' -%}
               {%- endif -%}
             {%- endif -%}
 


### PR DESCRIPTION
当默认 article_header.type = overlay 时，没有 cover 的文章将会显示错误的背景图片。