### PR TITLE
Add multi-language support for Gitalk

### DIFF
--- a/_includes/comments-providers/gitalk.html
+++ b/_includes/comments-providers/gitalk.html
@@ -30,7 +30,8 @@
 				repo: '{{ site.comments.gitalk.repository }}',
 				owner: '{{ site.comments.gitalk.owner }}',
 				admin: [{{ _admin }}],
-				id: '{{ page.key }}'
+				id: '{{ page.key }}',
+				language: '{{ site.lang }}',
 			});
 			gitalk.render('js-gitalk-container');
 		});


### PR DESCRIPTION
Gitalk's interface is always Chinese despite `site.lang` is `en`. So now I fixed it.