### PR TITLE
Add missing close li tag in author-links.html

### DIFF
--- a/_includes/author-links.html
+++ b/_includes/author-links.html
@@ -25,6 +25,7 @@
       <a class="button button--circle mail-button" itemprop="email" href="mailto:{{ _author.email }}" target="_blank">
         <i class="fas fa-envelope"></i>
       </a>
+    </li>
     {%- endif -%}
 
 


### PR DESCRIPTION
This doesn't end up mattering in the footer, but it does if you try to include author-links.html in the body of a page.

Thanks for making this theme!