### PR TITLE
Update the bundle install command

### DIFF
--- a/docs/_docs/en/1.1-quick-start.md
+++ b/docs/_docs/en/1.1-quick-start.md
@@ -107,7 +107,7 @@ If you want to run them them locally, you need first install Ruby and Jekyll, se
 After that, run bundler to install the dependencies:
 
 ```bash
-bundle install --path vendor/bundle
+bundle config set path 'vendor/bundle'
 ```
 
 And also, TeXt offer [Docker](https://www.docker.com/) support for development and public, this make it easier to setup environment.


### PR DESCRIPTION
While using the `bundle install --path vendor/bundle` it is showing that it has been deprecated and will no longer work in future versions. Hence updated with newer command.