### PR TITLE
fix: deprecated youtube link (#277)

### DIFF
--- a/_includes/extensions/youtube.html
+++ b/_includes/extensions/youtube.html
@@ -1,4 +1,4 @@
 <div class="extensions extensions--video">
-  <iframe src="https://www.youtube.com/embed/{{ include.id }}?rel=0&showinfo=0"
+  <iframe src="https://www.youtube.com/embed/{{ include.id }}?rel=0"
     frameborder="0" scrolling="no" allowfullscreen></iframe>
 </div>


### PR DESCRIPTION
Fixed the deprecated youtube link. (explained on issue #277 )
