### PR TITLE
Fixed spelling mistake in Layouts documentation

### DIFF
--- a/docs/_docs/en/2.3-layouts.md
+++ b/docs/_docs/en/2.3-layouts.md
@@ -128,7 +128,7 @@ Base on Page Layout, available since version **2.2.0**.
 | Variable          | Option Values         | Description |
 | ---               | ---                   | ---         |
 | **data_source**   | `!!str`               | You can set it as a collections name, then the page will show the article list of this collections. You can refer to [Collections](https://jekyllrb.com/docs/collections/) to learn more about collections. |
-| **type**          | item, brief, grid | TeXt supports 3 article list type with various settings, yan can find examples [HERE](https://tianqi.name/jekyll-TeXt-theme/samples.html#articles-layout). |
+| **type**          | item, brief, grid | TeXt supports 3 article list type with various settings, you can find examples [HERE](https://tianqi.name/jekyll-TeXt-theme/samples.html#articles-layout). |
 | **size**          | md, sm        | Available when type is `grid`. |
 | **article_type**  | BlogPosting       | Available when type is `normal`. |
 | **show_cover**    | true (default), false | Available when type is `normal`. Before set it to `true`, you need first set each article a cover image, refer to the `cover` variable in [Page Layout](#page-layout). |


### PR DESCRIPTION
`yan can find` -> `you can find`