### PR TITLE
Fixed "gitalk request failed with status code 403"

### DIFF
--- a/_data/variables.yml
+++ b/_data/variables.yml
@@ -46,8 +46,8 @@ sources:
     leancloud_js_sdk: '//cdn.jsdelivr.net/npm/leancloud-storage@3.13.2/dist/av-min.js'
     chart: 'https://cdn.bootcss.com/Chart.js/2.7.2/Chart.bundle.min.js'
     gitalk:
-      js: 'https://cdn.bootcss.com/gitalk/1.2.2/gitalk.min.js'
-      css: 'https://cdn.bootcss.com/gitalk/1.2.2/gitalk.min.css'
+      js: 'https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.min.js'
+      css: 'https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.css'
     valine: 'https://unpkg.com/valine/dist/Valine.min.js' # bootcdn not available
     mathjax: 'https://cdn.bootcss.com/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_CHTML'
     mermaid: 'https://cdn.bootcss.com/mermaid/8.0.0-rc.8/mermaid.min.js'
@@ -57,8 +57,8 @@ sources:
     leancloud_js_sdk: '//cdn.jsdelivr.net/npm/leancloud-storage@3.13.2/dist/av-min.js'
     chart: 'https://unpkg.com/chart.js@2.7.2/dist/Chart.min.js'
     gitalk:
-      js: 'https://unpkg.com/gitalk@1.2.2/dist/gitalk.min.js'
-      css: 'https://unpkg.com/gitalk@1.2.2/dist/gitalk.css'
+      js: 'https://unpkg.com/gitalk/dist/gitalk.min.js'
+      css: 'https://unpkg.com/gitalk/dist/gitalk.css'
     valine: 'https//unpkg.com/valine/dist/Valine.min.js'
     mathjax: 'https://unpkg.com/mathjax@2.7.4/unpacked/MathJax.js?config=TeX-MML-AM_CHTML'
     mermaid: 'https://unpkg.com/mermaid@8.0.0-rc.8/dist/mermaid.min.js'


### PR DESCRIPTION
Hi, I am a user of your excellent Jekyll theme. I was trying to add gitalk to my blog. However, the error "gitalk error request failed with status code 403" happened when I deployed the original theme on Github pages. Here is the detailed reason for this issue (https://github.com/gitalk/gitalk/issues/429).

I found that this issue was fixed by the latest gitalk (gitalk v1.2.2 to latest v1.7.2). Thus, I updated the dependency file.

I hope it could help others who also suffer from this issue.

Thanks for your brilliant work!