### PR TITLE
Fixed comments code

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -22,8 +22,10 @@ type: article
     {%- include article-section-navigator.html -%}
   </div>
 
+  {%- if _comment != false -%}
+    <section class="page__comments d-print-none">{%- include comments.html -%}</section>
+  {%- endif -%}
 </div>
-
 <script>
   {%- include scripts/article.js -%}
 </script>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -210,9 +210,6 @@ layout: base
                 {%- endif -%}
 
                     <div class="js-article-content">{{ content }}</div>
-                    {%- if _comment != false -%}
-                      <section class="page__comments d-print-none">{%- include comments.html -%}</section>
-                    {%- endif -%}
                 </article>
                 {%- include main/bottom/custom.html -%}
               </div>

--- a/_sass/layout/_article.scss
+++ b/_sass/layout/_article.scss
@@ -27,3 +27,6 @@
     text-align: right;
   }
 }
+.page__comments {
+  margin: map-get($spacers, 4) 0;
+}

--- a/_sass/layout/_page.scss
+++ b/_sass/layout/_page.scss
@@ -53,11 +53,6 @@ html,
     padding-bottom: 0;
   }
 }
-
-.page__comments {
-  margin: map-get($spacers, 4) 0;
-}
-
 .page__aside {
   .toc-aside {
     padding: map-get($spacers, 5) 0 map-get($spacers, 3) map-get($spacers, 5);


### PR DESCRIPTION
Hello, TeXt theme is awesome jekyll theme.
but, if you add comments-provider, it is added not only in article(blog posts), but also in "idex.html", "archive.html" everywhere.
So I moved comments-provider code from "_layouts/page.html" to "_layout/article.html"

Thank you