### PR TITLE
Make the e-mail social button match the rest

### DIFF
--- a/_includes/author-links.html
+++ b/_includes/author-links.html
@@ -23,7 +23,7 @@
     {%- if _author.email -%}
       <li title="{{ _locale_string_email }}">
       <a class="button button--circle mail-button" itemprop="email" href="mailto:{{ _author.email }}" target="_blank">
-        <i class="fas fa-envelope"></i>
+        <div class="icon">{%- include svg/icon/social/mail.svg -%}</div>
       </a>
     {%- endif -%}
 


### PR DESCRIPTION
This change renders the `mail` icon in the author links section,
to avoid having a blank icon:

![image](https://user-images.githubusercontent.com/5479513/172978018-ccf8026e-4ad7-4f2c-90d3-dea00c114b4b.png)