### PR TITLE
fix text color in the comment area of gitalk

### DIFF
--- a/_includes/comments-providers/gitalk.html
+++ b/_includes/comments-providers/gitalk.html
@@ -10,6 +10,9 @@
 		.gitalk-wrapper .gt-header-textarea {
 			color: #333 !important;
 		}
+		.markdown-body *{
+			color: #333 !important;
+		}
 	</style>
 
 	{%- include snippets/get-sources.html -%}


### PR DESCRIPTION
see in issue [#144](https://github.com/kitian616/jekyll-TeXt-theme/issues/144#issuecomment-1232518250)