### PR TITLE
Upgrade Mermaid JS to 9.2.2

### DIFF
--- a/test/_data/variables.yml
+++ b/test/_data/variables.yml
@@ -50,7 +50,7 @@ sources:
       css: 'https://cdn.bootcss.com/gitalk/1.2.2/gitalk.min.css'
     valine: 'https://unpkg.com/valine/dist/Valine.min.js' # bootcdn not available
     mathjax: 'https://cdn.bootcss.com/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_CHTML'
-    mermaid: 'https://cdn.bootcss.com/mermaid/8.0.0-rc.8/mermaid.min.js'
+    mermaid: 'https://cdn.bootcss.com/mermaid/9.2.2/mermaid.min.js'
   unpkg:
     font_awesome: 'https://use.fontawesome.com/releases/v5.15.1/css/all.css'
     jquery: 'https://unpkg.com/jquery@3.3.1/dist/jquery.min.js'
@@ -61,4 +61,4 @@ sources:
       css: 'https://unpkg.com/gitalk@1.2.2/dist/gitalk.css'
     valine: 'https//unpkg.com/valine/dist/Valine.min.js'
     mathjax: 'https://unpkg.com/mathjax@2.7.4/unpacked/MathJax.js?config=TeX-MML-AM_CHTML'
-    mermaid: 'https://unpkg.com/mermaid@8.0.0-rc.8/dist/mermaid.min.js'
+    mermaid: 'https://unpkg.com/mermaid@9.2.2/dist/mermaid.min.js'


### PR DESCRIPTION
This PR upgrades the [Mermaid JS](https://mermaid-js.github.io/mermaid/#/) library to 9.2.2. This allows Jekyll TeXt Theme to support more Mermaid syntax. For example, the sequence diagram [demo](https://mermaid-js.github.io/mermaid/syntax/sequenceDiagram.html) is not supported in 8.0.0.

```
sequenceDiagram
    Alice->>John: Hello John, how are you?
    John-->>Alice: Great!
    Alice-)John: See you later!
```

```mermaid
sequenceDiagram
    Alice->>John: Hello John, how are you?
    John-->>Alice: Great!
    Alice-)John: See you later!
```

This is tested in my blog post ["Internal Working of the GitLab API Go Client"](https://mincong.io/en/go-gitlab/) under commit https://github.com/mincong-h/mincong-h.github.io/pull/75/commits/740b1a978dbed56d913946dedb1eade4c083efb2