### PR TITLE
add proxy for gitalk

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -131,6 +131,7 @@ comments:
     clientSecret: # GitHub Application Client Secret
     repository  : # GitHub repo
     owner       : # GitHub repo owner
+    proxy: # "https://vercel.prohibitorum.top/github_access_token"
     admin: # GitHub repo owner and collaborators, only these guys can initialize GitHub issues, IT IS A LIST.
       # - your GitHub Id
 

--- a/_includes/comments-providers/gitalk.html
+++ b/_includes/comments-providers/gitalk.html
@@ -29,6 +29,7 @@
 				clientSecret: '{{ site.comments.gitalk.clientSecret }}',
 				repo: '{{ site.comments.gitalk.repository }}',
 				owner: '{{ site.comments.gitalk.owner }}',
+				proxy: '{{ site.comments.gitalk.proxy }}',
 				admin: [{{ _admin }}],
 				id: '{{ page.key }}'
 			});

--- a/docs/_docs/zh/2.1-configuration.md
+++ b/docs/_docs/zh/2.1-configuration.md
@@ -262,7 +262,7 @@ comments:
     id: "your-addthis-pubid"
 ```
 
-你需要在页面的头信息里设置 `sharing` 属性为 `true` 来开启该页的评论，详情请戳 [这里](https://kitian616.github.io/jekyll-TeXt-theme/docs/zh/layouts#article-%E5%B8%83%E5%B1%80)。
+你需要在页面的头信息里设置 `sharing` 属性为 `true` 来开启该页的分享，详情请戳 [这里](https://kitian616.github.io/jekyll-TeXt-theme/docs/zh/layouts#article-%E5%B8%83%E5%B1%80)。
 {:.warning}
 
 ## 评论


### PR DESCRIPTION
1. 文档中的sharing配置是用来控制分享功能，不是评论。
2. gitalk网络连接失败，增加代理，解决无法登录的问题。