### PR TITLE
(Views Counter) Update LeanCloud server URL initialization

### DIFF
--- a/_includes/pageview-providers/leancloud/leancloud.js
+++ b/_includes/pageview-providers/leancloud/leancloud.js
@@ -13,7 +13,7 @@
     appKey = options.appKey;
     appClass = options.appClass;
     AV.init({
-      serverURLs: 'https://avoscloud.com',
+      serverURL: 'https://' + appId + '.api.lncldglobal.com',
       appId: appId,
       appKey: appKey
     });


### PR DESCRIPTION
Views are not being added to the posts, they remain in zero.

The reason is that LeanCloud doesn't use avoscloud.com for its server anymore, neither serverURLs as a variable. Instead, you must use serverURL (in singular) and I corrected the new server; it's working for me.